### PR TITLE
sort output file by processor rank

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ MIN_IT = 0      #minimum number of iterations
 MAX_IT = 15     #maximum number of iterations
 SQUARES_ONLY = True
 WRAP_AROUND = True
+SORT_OUTPUT = False
 
 def read_field(filename):
     with open(filename, 'r') as f:
@@ -115,10 +116,17 @@ def launch_executable(executable_path, np, it, case_idx):
         print(' '.join(command))
         subprocess.run(command, stdout=out_file, stderr=err_file)
 
+    with open(f'./tests/case_{case_idx}/case_{case_idx}_np_{np}_it_{it}.out.sorted', 'w') as out_file:
+        command = ['sort', '-t', ':', '-g', '-k', '1,1', '-s', f'./tests/case_{case_idx}/case_{case_idx}_np_{np}_it_{it}.out']
+        subprocess.run(command, stdout=out_file)
+
 def compare_results(idx, np, it):
     with open(f'./tests/case_{idx}/differences', 'a') as diff_file:
         reference_path = f'./tests/case_{idx}/i_{it}.txt'
         test_path = f'./tests/case_{idx}/case_{idx}_np_{np}_it_{it}.out'
+        if SORT_OUTPUT:
+            test_path += '.sorted'
+
         command = f"bash -c 'diff <(sed \"s/[0-9]*: //\" {test_path}) {reference_path}'"
         
         result = subprocess.run(command, shell=True, text=True, capture_output=True)

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,8 @@ Testy umoznuju testovat dva typy implementacie:
 1. Naklonujte repozitar.
 2. Skopirujte `life.cpp` a `test.sh` do ku `main.py` do jednej zlozky
 3. Nastavte `WRAP_AROUND` v `main.py` na `True`, ak vasa binarka implementuje wrap-around.
-4. Spustite `python3 main.py`
+4. Nastavte `SORT_OUTPUT` v `main.py` na `True`, ak vasa binarka generuje nesyncuje printy medzi procesmi
+5. Spustite `python3 main.py`
 
 #### Priebeh testu
 1. Vygenerovanie testcase-ov podla parametrov v `main.py`
@@ -34,7 +35,7 @@ Testy umoznuju testovat dva typy implementacie:
 #### ⚠️ Disclaimer
 * Testy su IBA orientacne.
 
-* Testy uplne ignoruju zaciatky riadkov obsahujuce `rank_id: `, kedze toto je velmi zavisle od zvolenej implementacie.
+* Testy uplne ignoruju zaciatky riadkov obsahujuce `rank_id: `, kedze toto je velmi zavisle od zvolenej implementacie. _Ak nemate zapnute `SORT_OUTPUT` - v tom pripade, sa riadky zoradia stabilnym sort algoritmom **len** podla ranku na zaciatku riadka._
 
 * Neviem ako budu testy fungovat na wine, ked tak niekto poslite PR s fixom.
 


### PR DESCRIPTION
If processes doesn't sync outputs it may happen, that playground rows are printed in incorrect order, e.g.:

```
1: 0010
1: 1101
0: 0000
0: 1000
```

The output is basically correct, however
it needs to be sorted to following form, since
`diff` doesn't care:

```
0: 0000
0: 1000
1: 0010
1: 1101
```

This patch does so, it sorts the values to `.sorted` file (by rank only, preserving relative order) and that one is used for comparison (if `SORT_OUTPUT` is set to `True`).